### PR TITLE
Fix after team migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Whenever a pull request is closed, a jira issue is created, updated with pr details, then a slack notification will be fired;
 
 
+
 example usage: 
 ```
    - name: do voodoo

--- a/helpers/jira-rest.js
+++ b/helpers/jira-rest.js
@@ -38,9 +38,7 @@ class Jira {
           "type": "doc",
           "version": 1
         },
-        customfield_10035: {
-          value: "Unassigned"
-        },
+        customfield_10001: null,
         issuetype: {
           name: config.JIRA_CONFIG.ISSUE_TYPE
         }


### PR DESCRIPTION
**NOTES:**

- after merge a version bump will occur and a new release will be created.
- version bump will only apply if you modify the `.github/workflows` directory (except `release.yaml`).
- by default the versioning is configured to bump the `patch` version of the script.

⚠ If you need to bump the `major` or `minor` version you should label this `PR` with either one of:

- `release:major` 
- `release:minor` 
